### PR TITLE
Fix of logspam and incorrect dv calculation

### DIFF
--- a/ScrapYard/Utilities/InventoryManagement.cs
+++ b/ScrapYard/Utilities/InventoryManagement.cs
@@ -71,7 +71,7 @@ namespace ScrapYard.Utilities
             }
 
             ScrapYardEvents.OnSYInventoryAppliedToVessel.Fire();
-            GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+            EditorHandling.UpdateCostUI();
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace ScrapYard.Utilities
                 }
             }
             ScrapYardEvents.OnSYInventoryAppliedToVessel.Fire();
-            GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+            EditorHandling.UpdateCostUI();
         }
 
         /// <summary>


### PR DESCRIPTION
Hi,
It looks like KSP developers changed how flowchart is running and they duplicates parts after we fire OnEditorShipModified.. So without this call it looks that KPS with ScrapYard is working correctly. 
Off course it can couse that some other mods will be not aware of Part changes in ship however still they can attach themselfs into:
OnSYInventoryAppliedToVessel Event.  

Test case
"
1. Create Ship.

Check dv
2. Click Launch and then restore ship
3. Go To VAB, dv will be lower
4. Delete all ship and build the same ship, dv will be lower.
"
Now it should work correctly.